### PR TITLE
include search order for ISPP does not match documentation

### DIFF
--- a/Projects/ISPP/Help/ispp.xml
+++ b/Projects/ISPP/Help/ispp.xml
@@ -242,8 +242,8 @@
 				</syntax>
 				<description>
 					<para>Includes the &translation; of the specified file.</para>
-					<para>If the filename is enclosed in angle brackets, ISPP first searches for the file in the directory where current file resides, then in the directory where the file that included current file resides, and so on. If the file is not found, it is searched on current include path, set via &pragma;, then on the path specified by INCLUDE environment variable.</para>
-					<para>If filename is an expression or specified in quotes, it is searched on current include path only.</para>
+					<para>If the filename is enclosed in quotes, ISPP first searches for the file in the directory where current file resides, then in the directory where the file that included current file resides, and so on. If the file is not found, it is searched on current include path, set via &pragma;, then on the path specified by INCLUDE environment variable.</para>
+					<para>If filename is an expression or specified in angle brackets, it is searched on current include path only.</para>
           <para>The filename may be prefixed by "compiler:", in which case it looks for the file in the Compiler directory.</para>
 					<para>This directive cannot be used inline.</para>
 				</description>


### PR DESCRIPTION
The behavior I see is that it's <filename> that searches only the current include path, and "filename" that also searches the directory where the current file resides. The observed behavior also matches what I would have expected based on the rest of ISPP being somewhat based on the C preprocessor and it's <system> and "local" include syntax.

The [code that seems to implement the rule](https://github.com/jrsoftware/issrc/blob/389d20804b25c7bc4bead2887e4e848845a901d3/Projects/ISPP/IsppTranslate.pas#L742-L747) is clearly setting IncludePathOnly := True when the <> delimiters *are* used.

So the documentation just appears to be backwards.